### PR TITLE
Conecta back front map filter

### DIFF
--- a/frontend/src/pages/AuthorizeLocalizationPage.tsx
+++ b/frontend/src/pages/AuthorizeLocalizationPage.tsx
@@ -28,7 +28,7 @@ const AuthorizeLocalizationPage = () => {
               navigate("/map-filter", { state: { coordinates, action } });
             })
             .catch(error =>{
-              console.log(error);
+              console.log("Serviço indisponível");
             })
             
           } else if (action === "register") {

--- a/frontend/src/pages/AuthorizeLocalizationPage.tsx
+++ b/frontend/src/pages/AuthorizeLocalizationPage.tsx
@@ -2,6 +2,9 @@ import { useNavigate, useLocation } from "react-router-dom";
 import Header from "../components/Header";
 import '../styles/AuthorizeLocalizationAndEmergencyPages.css';
 import FormIndex from "../components/FormIndex";
+import axios from "axios";
+
+const URL = "http://localhost:4000/map-filter";
 
 const AuthorizeLocalizationPage = () => {
   let navigate = useNavigate();
@@ -18,7 +21,16 @@ const AuthorizeLocalizationPage = () => {
           };
   
           if (action === "viewMap") {
-            navigate("/map-filter", { state: { coordinates, action } });
+            // Realiza a requisição get para pegar todas as ocorrências
+            axios.get(URL)
+            .then(occurrence_data =>{
+              console.log(occurrence_data)
+              navigate("/map-filter", { state: { coordinates, action } });
+            })
+            .catch(error =>{
+              console.log(error);
+            })
+            
           } else if (action === "register") {
             navigate("/form-about-violence", { state: { coordinates, action } });
           } else {


### PR DESCRIPTION
Conectamos o back com o front da página de visualização do mapa. Quando o usuário selecionar para visualizar o mapa e autorizar o acesso a sua localização, é feita uma requisição get no back e retorna todas as coordenas e respectivos tipos de violência presentes na tabela de Ocorrência. Caso retorne um erro, é exibida no terminal a mensagem "Serviço indisponível".