### PR TITLE
Correção das rotas, do mapa e do envio de dados

### DIFF
--- a/backend/prisma/migrations/20240628192317_ref_to_name_state/migration.sql
+++ b/backend/prisma/migrations/20240628192317_ref_to_name_state/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name_state]` on the table `state_list` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "occurrence" DROP CONSTRAINT "occurrence_fk1";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "state_list_name_state_key" ON "state_list"("name_state");
+
+-- AddForeignKey
+ALTER TABLE "occurrence" ADD CONSTRAINT "occurrence_fk1" FOREIGN KEY ("state_violence") REFERENCES "state_list"("name_state") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,7 +20,7 @@ model occurrence {
   longitude           Decimal          @db.Decimal(9, 6)
   violences_options   String
   violence_type       String
-  state_list          state_list       @relation(fields: [state_violence], references: [uf_state], onDelete: Cascade, onUpdate: Cascade, map: "occurrence_fk1")
+  state_list          state_list       @relation(fields: [state_violence], references: [name_state], onDelete: Cascade, onUpdate: Cascade, map: "occurrence_fk1")
   user_fingerprint    user_fingerprint       @relation(fields: [id_user], references: [id_user], onDelete: Cascade, onUpdate: Cascade, map: "occurrence_fk2")
   user_occurrences    user_occurrences[]
 }
@@ -28,7 +28,7 @@ model occurrence {
 model state_list {
   id_state        BigInt       @id @default(autoincrement())
   uf_state        String       @unique
-  name_state      String
+  name_state      String       @unique
   num_occurrences BigInt?      @default(0)
   occurrence      occurrence[]
 }

--- a/backend/src/protocols.ts
+++ b/backend/src/protocols.ts
@@ -35,7 +35,7 @@ export type OccurrenceData_bd = {
     violence_type: string
 }
 export type ViolenceState = {
-    uf_state:string,
+    state:string,
     city: string
 };
 // Tipo para receber no json (json não tem tipo data)

--- a/backend/src/repositories/formStatePage-repository.ts
+++ b/backend/src/repositories/formStatePage-repository.ts
@@ -18,38 +18,38 @@ const prisma = new PrismaClient();
 //     return occurrence
 // }
 
-async function getListUfs() {
-    const listUfs = await prisma.state_list.findMany({
+async function getListStates() {
+    const listStates = await prisma.state_list.findMany({
         select:{
             id_state: false,
-            uf_state: true,
-            name_state: false,
+            uf_state: false,
+            name_state: true,
             num_occurrences: false
         }
     })
-    return listUfs;
+    return listStates;
 }
 
-async function upd_numOccurrences_StateList(state: ViolenceState){
-    const {uf_state} = state;
-    const old_value = await prisma.state_list.findFirst({
-        where: {uf_state: uf_state},
-        select: {
-            num_occurrences: true
-        }
-    })
-    const new_value = old_value.num_occurrences + BigInt(1)
-    const updatedData = await prisma.state_list.update({
-        where:{ uf_state: uf_state},
-        data: {
-            num_occurrences: new_value
-        }
-    })
-}
+// async function upd_numOccurrences_StateList(violencestate: ViolenceState){
+//     const {state} = violencestate;
+//     const old_value = await prisma.state_list.findFirst({
+//         where: {name_state: state},
+//         select: {
+//             num_occurrences: true
+//         }
+//     })
+//     const new_value = old_value.num_occurrences + BigInt(1)
+//     const updatedData = await prisma.state_list.update({
+//         where: { name_state: state},
+//         data: {
+//             num_occurrences: new_value
+//         }
+//     })
+// }
 
 export const StatePageRepository = {
     // StateOccurrence,
-    getListUfs
+    getListStates,
     // upd_numOccurrences_StateList
 }
 

--- a/backend/src/repositories/mapPage-repository.ts
+++ b/backend/src/repositories/mapPage-repository.ts
@@ -44,16 +44,16 @@ async function createOccurrence(occurrencedata_bd:OccurrenceData_bd) {
     })
     return occurrence
 }
-async function upd_numOccurrences_StateList(uf_state: string){
+async function upd_numOccurrences_StateList(name_state: string){
     const old_value = await prisma.state_list.findFirst({
-        where: {uf_state: uf_state},
+        where: {name_state: name_state},
         select: {
             num_occurrences: true
         }
     })
     const new_value = old_value.num_occurrences + BigInt(1)
     const updatedData = await prisma.state_list.update({
-        where:{ uf_state: uf_state},
+        where:{ name_state: name_state},
         data: {
             num_occurrences: new_value
         }

--- a/backend/src/services/formStatePage-service.ts
+++ b/backend/src/services/formStatePage-service.ts
@@ -5,14 +5,14 @@ import { validationError,repositoryError } from "../errors/errors";
 
 async function validateStateOccur(violenceState: ViolenceState): Promise<any> {
 
-    const listUfs = StatePageRepository.getListUfs()
+    const listUfs = StatePageRepository.getListStates()
     //  const listOccur = await authorizationRepository.getListOccur()
-    if (!(await listUfs).find(state => state.uf_state == violenceState.uf_state)){
+    if (!(await listUfs).find(state => state.name_state == violenceState.state)){
         throw validationError('"State"');
     }
-    else if (typeof violenceState.uf_state !== 'string'){
+    else if (typeof violenceState.state !== 'string'){
         throw validationError('"State"');
-    } else if (!violenceState.uf_state||violenceState.uf_state==null){
+    } else if (!violenceState.state||violenceState.state==null){
         throw validationError('"State"');
     } else if (!violenceState.city||violenceState.city==null){
         throw validationError('"City"');

--- a/backend/src/services/mapPage-services.ts
+++ b/backend/src/services/mapPage-services.ts
@@ -15,7 +15,7 @@ async function createOccur(occurrencedata: OccurrenceData) {
     const id_user = await MapPageRepository.createUser(occurrencedata.fingerprint);
 
     //validação dos dados de novo (para evitar envios maliciosos)
-    await StatePageService.validateStateOccur({uf_state:occurrencedata.state_violence,city:occurrencedata.city_violence});
+    await StatePageService.validateStateOccur({state:occurrencedata.state_violence,city:occurrencedata.city_violence});
 
     await AboutViolencePageService.validateAboutViolenceOccur({date_violence_s: occurrencedata.date_violence_s, agegroup: occurrencedata.age_group, time_violence_s: occurrencedata.time_violence_s});
 
@@ -45,7 +45,7 @@ async function createOccur(occurrencedata: OccurrenceData) {
     try {
         const occurrence = await MapPageRepository.createOccurrence(occurrencedata_bd);
         await MapPageRepository.upd_user_occurrences(occurrence.id_occurrence, occurrence.date_violence, occurrence.id_user);
-        return 'ok';
+        return occurrence;
     } catch {
         throw repositoryError('"Occurrence"','"createOccur"')
     }

--- a/frontend/src/pages/AuthorizeLocalizationPage.tsx
+++ b/frontend/src/pages/AuthorizeLocalizationPage.tsx
@@ -34,7 +34,7 @@ const AuthorizeLocalizationPage = () => {
             });
 
           } else if (action === "register") {
-            navigate("/form-about-violence", { state: { coordinates, action } });
+            navigate("/map-address", { state: { coordinates, action } });
           } else {
             console.error("Unsupported action.");
           }
@@ -78,7 +78,7 @@ const AuthorizeLocalizationPage = () => {
       <Header />
       <main>
         <section className="page">
-          <FormIndex value={1}/>
+          <FormIndex value={4}/>
         </section>
 
         <section className="question">

--- a/frontend/src/pages/FormAboutViolencePage.tsx
+++ b/frontend/src/pages/FormAboutViolencePage.tsx
@@ -122,14 +122,14 @@ const handleNext = () => {
             <Header />
             <main className="main-about-violence">
                 <section className="page">
-                    <FormIndex value={2}/>
+                    <FormIndex value={1}/>
                 </section>
 
                 <section className="area-question">
                     <div className="questions">
                         <div>
                             <p className="text">Sinta-se à vontade para compartilhar conosco algumas informações sobre a violência que você enfrentou.</p>
-                            <label htmlFor="dateInput" className="date-input">2. Que dia ocorreu a violência?</label>
+                            <label htmlFor="dateInput" className="date-input">1. Que dia ocorreu a violência?</label>
                             <input
                                 type="date"
                                 id="dateInput"
@@ -138,7 +138,7 @@ const handleNext = () => {
                             />
                         </div>
                         <div>
-                            <label htmlFor="timeInput" className="time-input">3. Qual foi o horário do ocorrido?</label>
+                            <label htmlFor="timeInput" className="time-input">2. Qual foi o horário do ocorrido?</label>
                             <input
                                 type="time"
                                 id="timeInput"
@@ -147,7 +147,7 @@ const handleNext = () => {
                             />
                         </div>
                         <div>
-                            <label htmlFor="ageRangeInput" className="age-input">4. Qual a sua faixa etária?</label>
+                            <label htmlFor="ageRangeInput" className="age-input">3. Qual a sua faixa etária?</label>
                             <select
                                 id="ageRangeInput"
                                 value={ageRange}

--- a/frontend/src/pages/FormClassifyViolencePage.tsx
+++ b/frontend/src/pages/FormClassifyViolencePage.tsx
@@ -75,7 +75,7 @@ const FormClassifyViolencePage = () => {
 
         setError(null);
         console.log (response);
-        navigate("/map-address", { state: state }); // Passando o estado para a próxima página
+        navigate("/authorize-localization", { state:{action : 'register'} }); // Passando o estado para a próxima página
       })
 
       .catch(error => {
@@ -96,12 +96,12 @@ const FormClassifyViolencePage = () => {
       <main>
         <section className="holepage">
           <section className="page">
-            <FormIndex value={3}/>
+            <FormIndex value={2}/>
           </section>
 
           <section className="prompt">
             <h4>Que situações você vivenciou durante o episódio de violência? Estamos aqui para compreender de forma gentil e acolhedora.</h4>
-            <p>5. Selecione situações que você identificou durante o episódio:</p>
+            <p>4. Selecione situações que você identificou durante o episódio:</p>
           </section>
 
           <section className="forms">

--- a/frontend/src/pages/FormStatePage.tsx
+++ b/frontend/src/pages/FormStatePage.tsx
@@ -6,7 +6,6 @@ import FormIndex from "../components/FormIndex";
 import FormCityOption from "../components/FormCityOption";
 import FormStateOption from "../components/FormStateOption";
 import { useNavigate, useLocation } from 'react-router-dom';
-import axios from "axios";
 
 const URL = "http://localhost:4000/form-state"
 
@@ -53,50 +52,29 @@ const FormStatePage = () => {
   }, [selectedState]);
 
   const handleNext = async () => {
+    console.log(selectedState)
     if (!selectedState || !selectedCity) {
       setError("Por favor, selecione o Estado e a Cidade.");
-    } else {
-
-      const flag = await axios.post(URL, {
-          // Corpo da requisição contendo os dados a serem enviados, deve ser igual ao json esperado pelo back
-          "uf_state": selectedState,
-          "city": selectedCity
-      }, {
-          // Cabeçalhos da requisição, importante para converter para json
-          headers: {
-              'Content-Type': 'application/json'
-          }
-      })
-      .then (response=>{
-        setError(null);
-        console.log(response);
-        return true;
-      })
-      .catch(error=>{
-        console.log(error);
-        setError("Dados inválidos");
-        return false;
-      })
-      if (flag){
-        try {
-          const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${selectedCity},${selectedState}`);
-          const data = await response.json();
-          if (data.length > 0) {
-            const { lat, lon } = data[0];
-            const coordinates = { lat, lon };
-            if (action === 'viewMap') {
-              navigate("/map-filter", { state: { coordinates } });
-            } else {
-              navigate("/map-address",{state: {coordinates, action:'register'}});
-            }
+    } else {      
+      try {
+        const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&q=${selectedCity},${selectedState}`);
+        const data = await response.json();
+        if (data.length > 0) {
+          const { lat, lon } = data[0];
+          const coordinates = { lat, lon };
+          if (action === 'viewMap') {
+            navigate("/map-filter", { state: { coordinates } });
           } else {
-            setError("Não foi possível encontrar as coordenadas da cidade selecionada.");
+            navigate("/map-address",{state: {coordinates, action:'register'}});
           }
-        } catch (error) {
-          console.error('Erro ao buscar coordenadas:', error);
-          setError("Erro ao buscar coordenadas. Tente novamente.");
+        } else {
+          setError("Não foi possível encontrar as coordenadas da cidade selecionada.");
         }
+      } catch (error) {
+        console.error('Erro ao buscar coordenadas:', error);
+        setError("Erro ao buscar coordenadas. Tente novamente.");
       }
+      
     }
   };
 

--- a/frontend/src/pages/FormStatePage.tsx
+++ b/frontend/src/pages/FormStatePage.tsx
@@ -87,7 +87,7 @@ const FormStatePage = () => {
             if (action === 'viewMap') {
               navigate("/map-filter", { state: { coordinates } });
             } else {
-              navigate("/form-about-violence");
+              navigate("/map-address",{state: {coordinates, action:'register'}});
             }
           } else {
             setError("Não foi possível encontrar as coordenadas da cidade selecionada.");

--- a/frontend/src/pages/MapAddress.tsx
+++ b/frontend/src/pages/MapAddress.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { MapContainer, TileLayer, Marker, useMapEvents } from 'react-leaflet';
+import { MapContainer, TileLayer, Marker, useMapEvents, useMap } from 'react-leaflet';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { RxDividerHorizontal } from "react-icons/rx";
 import 'leaflet/dist/leaflet.css';
-import { LatLng } from 'leaflet';
+import { LatLng, LatLngExpression } from 'leaflet';
 import { icon } from 'leaflet';
 import LocationIcon from "../assets/location_icon.png"; 
 import '../styles/MapPageAddress.css';
@@ -13,7 +13,9 @@ function Mapa() {
   const navigate = useNavigate();
   const location = useLocation();
   const { state } = location;
+  const { coordinates } = location.state || {}; 
   const [markerPosition, setMarkerPosition] = useState<LatLng | null>(null);
+
   const [locationSelected, setLocationSelected] = useState(false);
   const [address, setAddress] = useState<string>(""); 
   const customIcon = icon({
@@ -21,6 +23,14 @@ function Mapa() {
     iconSize: [28, 28], 
     iconAnchor: [16, 48], 
   });
+
+  function ChangeMapView({ center }: { center: LatLngExpression }) {
+    const map = useMap();
+    if (center) {
+      map.setView(center, 12);
+    }
+    return null;
+  }
 
   useEffect(() => {
     if (markerPosition) {
@@ -75,6 +85,7 @@ function Mapa() {
         </div>
       </div>
 
+
       <MapContainer
         center={markerPosition ? [markerPosition.lat, markerPosition.lng] : [-15.794, -47.882]}
         zoom={14}
@@ -92,8 +103,11 @@ function Mapa() {
           <Marker position={markerPosition} icon={customIcon}>
           </Marker>
         )}
+        <ChangeMapView center={coordinates ? [coordinates.lat, coordinates.lon] : [-15.794, -47.882]} />
 
       </MapContainer>
+
+      
 
       {locationSelected && (
         

--- a/frontend/src/pages/MapAddress.tsx
+++ b/frontend/src/pages/MapAddress.tsx
@@ -18,6 +18,8 @@ function Mapa() {
 
   const [locationSelected, setLocationSelected] = useState(false);
   const [address, setAddress] = useState<string>(""); 
+  const [city_v,setCity_v] = useState<string>(""); 
+  const [state_v,setState_v] = useState<string>(""); 
   const customIcon = icon({
     iconUrl: LocationIcon, 
     iconSize: [28, 28], 
@@ -52,8 +54,10 @@ function Mapa() {
       const { road, suburb, city, state, postcode, country } = data.address;
       const addressParts = [road, suburb, city, state, postcode, country].filter(Boolean);
       const address = addressParts.join(', ');
-      
+
       setAddress(address);
+      setCity_v(city)
+      setState_v(state)
     } catch (error) {
       console.error('Erro ao obter o endereço:', error);
       setAddress('Erro ao obter o endereço'); 
@@ -72,7 +76,7 @@ function Mapa() {
   }
 
   const handleNextClick = () => {
-    navigate('/map-page', { state: { address } });
+    navigate('/map-page', { state: { address,markerPosition,city_v,state_v } });
   };
 
   return (

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -103,7 +103,7 @@ function Mapa() {
           </div>
 
           <div className="map-info">
-            <label>HORÁRIO RELATADO:</label> <span className="address-style">{localStorage.getItem('time')}</span> 
+            <label>HORÁRIO DO OCORRIDO:</label> <span className="address-style">{localStorage.getItem('time')}</span> 
           </div>
 
           <div className="map-info">

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -15,7 +15,8 @@ const URL = "http://localhost:4000/map-page"
 function Mapa() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { address } = location.state || {};
+  const { address,markerPosition,city_v,state_v} = location.state || {};
+
   const oldDate = localStorage.getItem('date') || ''
   const [year,month,day] = oldDate.split('-');
   const formatedDate = `${day}/${month}/${year}`;
@@ -27,16 +28,18 @@ function Mapa() {
     console.log('Fingerprint:', fingerprint);
 
     localStorage.setItem('fingerprint', fingerprint);
-
+    // console.log(markerPosition)
+    console.log(city_v)
+    console.log(state_v)
     axios.post(URL, {
       "fingerprint" : fingerprint,
       "age_group": localStorage.getItem('ageRange'),
       "date_violence_s": localStorage.getItem('date'),
       "time_violence_s": "T" + localStorage.getItem('time') + ":00-03:00",
-      "city_violence": 'Brasilia',
-      "state_violence":'DF',
-      "latitude": -15,
-      "longitude": -15,
+      "city_violence": city_v,
+      "state_violence":state_v,
+      "latitude": markerPosition.lat,
+      "longitude": markerPosition.lng,
       "violence_options": 'VS1',
       "violence_type": 'VT3'
     }, {
@@ -75,7 +78,7 @@ function Mapa() {
       </div>
 
       <MapContainer
-        center={[-15.794, -47.882]}
+        center={[markerPosition.lat, markerPosition.lng]}
         zoom={14}
         style={{ width: '100vw', height: '100vh' }}
         zoomControl={false}
@@ -86,7 +89,7 @@ function Mapa() {
         />
 
         {address && (
-          <Marker position={[-15.794, -47.882]} icon={customIcon}>
+          <Marker position={[markerPosition.lat, markerPosition.lng]} icon={customIcon}>
           </Marker>
         )}
       </MapContainer>

--- a/frontend/src/pages/WhatToDoPage.tsx
+++ b/frontend/src/pages/WhatToDoPage.tsx
@@ -32,7 +32,7 @@ const WhatToDoPage = () => {
                     <nav className="navigation">
                         <section className="violence-registration">
                             <FaHand className="FaHand" />
-                            <button className="button-violence" onClick={() => navigate("/authorize-localization", { state: { action: 'register' } })}>Fazer um registro</button>
+                            <button className="button-violence" onClick={() => navigate("/form-about-violence", { state: { action: 'register' } })}>Fazer um registro</button>
                         </section>
 
                         <section className="map-visualization">


### PR DESCRIPTION
- Colocamos a seleção do local da violência e autorização da localização para o final do formulário.
- Agora o mapa abre próximo ao usuário.
- A coordenada selecionada é mostrada na tela map-page e enviada para o backend.
- Na tela form-state-page não é mais realizada a validação dos dados selecionados.
- Na tabela ocorrência, o estado salva agora o nome completo em vez da string devido à dificuldades de gerar a UF do estado partindo da coordenada selecionada. Para tanto, realizamos mudanças no backend para validar o nome completo armazenado na tabela state_list.