### PR TITLE
Handlenext map adress

### DIFF
--- a/frontend/src/pages/MapAddress.tsx
+++ b/frontend/src/pages/MapAddress.tsx
@@ -23,6 +23,7 @@ function Mapa() {
     iconSize: [28, 28], 
     iconAnchor: [16, 48], 
   });
+  const [erroAddress,setErroAddress] = useState<boolean>(true)
   
   useEffect(() => {
     if (markerPosition) {
@@ -41,9 +42,11 @@ function Mapa() {
       setAddress(address);
       setCity_v(city)
       setState_v(state)
+      setErroAddress(false)
       
     } catch (error) {
       console.error('Erro ao obter o endereço:', error);
+      setErroAddress(true)
       setAddress('Erro ao obter o endereço'); 
     }
   };
@@ -60,8 +63,12 @@ function Mapa() {
   }
 
   const handleNextClick = () => {
+    if (erroAddress){
+      alert('Erro ao obter endereço')
+    } else {
     console.log(city_v);
     navigate('/map-page', { state: { address,markerPosition,city_v,state_v } });
+    }
   };
 
   return (

--- a/frontend/src/pages/MapAddress.tsx
+++ b/frontend/src/pages/MapAddress.tsx
@@ -114,7 +114,7 @@ function Mapa() {
           </div>
 
           <div className="btn-map">
-            <button className="btn btn-finish-address" onClick={handleNextClick}>Confirmo este local</button>
+            <button className="btn btn-finish-address" onClick={handleNextClick}>Confirmar local</button>
           </div>
         </div>
       )}


### PR DESCRIPTION
- Adicionamos um alerta caso tenha havido errado ao capturar o endereço na tela `map-adress`. Nesse caso, o usuário não consegue passar para a próxima tela.
- Mudamos o texto do botão da map-adress para 'Confirmar local'.